### PR TITLE
fix: improve skill clarity, add Tessl review workflows

### DIFF
--- a/.claude/skills/coquill-analyzer/SKILL.md
+++ b/.claude/skills/coquill-analyzer/SKILL.md
@@ -27,7 +27,7 @@ python <script_path> <template_dir> [--force]
 
 Pass `--force` if the Orchestrator requests re-analysis (skips the cache check).
 
-The script handles: format detection, caching, text extraction (including docx XML merge), two-pass analysis, type inference, condition parsing, loop sub-variable extraction, dependency graph construction, config.yaml merge, and manifest save.
+The script handles: format detection, caching, text extraction (including docx XML merge), two-pass analysis, type inference, condition parsing, loop sub-variable extraction, dependency graph construction, config.yaml merge, and manifest save. For implementation details, see `scripts/analyze.py`.
 
 ### Interpret Script Output
 

--- a/.claude/skills/coquill-renderer/SKILL.md
+++ b/.claude/skills/coquill-renderer/SKILL.md
@@ -70,8 +70,8 @@ Do NOT attempt `docx2pdf` or `soffice` in Cowork — they fail due to sandbox re
 The script's JSON output includes a `validation` object:
 
 - **`validation.passed == true`**: All placeholders and control tags were processed. The document is ready.
-- **`validation.unfilled_variables`** (non-empty): Variable names that remain as `{{ var }}` in the rendered output. Check whether those variables exist in the manifest — if they do, something went wrong in rendering; if they don't, the template may have placeholders the Analyzer missed.
-- **`validation.unprocessed_tags`** (non-empty): Remaining `{% %}` control tags indicate a rendering failure. Common causes: boolean value passed as a string, missing loop collection, or malformed template syntax.
+- **`validation.unfilled_variables`** (non-empty): Variable names that remain as `{{ var }}` in the output — cross-check against the manifest to determine if it is a rendering bug or an Analyzer gap.
+- **`validation.unprocessed_tags`** (non-empty): Remaining `{% %}` control tags — likely a boolean passed as a string, missing loop collection, or malformed template syntax.
 
 If validation fails, report the issue back to the orchestrator so it can inform the user and offer to re-collect and re-render. Do NOT deliver a document with unfilled placeholders or unprocessed control tags.
 
@@ -87,4 +87,4 @@ Return to the orchestrator:
 ## Important Notes
 
 - **For docx templates**, always use `docxtpl` — not raw python-docx with string replacement. `docxtpl` preserves formatting around placeholders and natively supports Jinja2 control tags.
-- **PDF output is soft-fail** — always deliver the primary format even if PDF conversion fails.
+- For render script internals (boolean coercion, job folder naming, template engine selection), see `scripts/render.py`.

--- a/.claude/skills/coquill-transcriber/SKILL.md
+++ b/.claude/skills/coquill-transcriber/SKILL.md
@@ -25,9 +25,17 @@ transcript of every micro-turn. When a user answered multiple questions at once,
 records the net result. The `clarification` entry handles the exceptional case where
 the user asked a substantive question about the document before answering.
 
+## Pre-flight Check
+
+Before invoking the script, verify the required input files exist:
+- `interview_log.json` at the provided `interview_log_path`
+- `manifest.yaml` at the provided `manifest_path`
+
+If either is missing, report the error to the Orchestrator immediately — do not invoke the script.
+
 ## Run the Script
 
-Resolve the script path relative to the project root and invoke it:
+Resolve the script path: use `$CLAUDE_PLUGIN_ROOT/scripts/transcribe.py` when `CLAUDE_PLUGIN_ROOT` is set, otherwise `scripts/transcribe.py` relative to the project root.
 
 ```bash
 python scripts/transcribe.py \

--- a/.claude/skills/coquill/SKILL.md
+++ b/.claude/skills/coquill/SKILL.md
@@ -90,23 +90,9 @@ Initialize the log with one entry:
 `2026-03-01T12:03:00+08:00`). For `question` entries, timestamp is when Claude sent the
 question; for `answer` entries, when the user's response was received.
 
-Entry types appended during Phases 4 and 5:
-  prefill           — variables extracted from opening message (list of {name, label, value})
-  group_start       — begins a named group (branch: "if"/"else"/"skipped" for conditionals)
-  question          — effective question(s) asked in one turn; include `questions` (array of variable names asked about)
-  clarification     — substantive user question + Claude's response (user_question, claude_response)
-  answer            — effective final answer, near-verbatim
-  validation_retry  — re-ask after failed validation (reason)
-  skip              — variable/group skipped, with human-readable reason
-  loop_item         — confirmed loop item (item_index, question, answer, values dict)
-  correction        — Phase 5 edit (field, label, old_value, new_value, optional note)
+Entry types appended during Phases 4 and 5: `prefill` (variables from opening message), `group_start` (named group, with branch for conditionals), `question` (questions array), `clarification` (user_question + claude_response), `answer` (near-verbatim), `validation_retry` (reason), `skip` (reason), `loop_item` (item_index, question, answer, values), `correction` (field, label, old_value, new_value).
 
-Entry type appended when a skill or script is invoked:
-  tool_use          — records a skill/script invocation:
-                        tool: skill or script name (e.g. "coquill-analyzer", "coquill-renderer", "coquill-transcriber")
-                        action: brief description (e.g. "Parsed template and generated manifest")
-                        timestamp: when invoked (ISO 8601)
-                        completed_at: when finished (ISO 8601)
+`tool_use` entries record skill/script invocations: `tool`, `action`, `timestamp`, `completed_at`.
 
 This log is scoped to ONE document assembly. Reset it at the start of Phase 3d whenever
 you begin preparing a new document.

--- a/.github/workflows/skill-review-and-optimize.yml
+++ b/.github/workflows/skill-review-and-optimize.yml
@@ -1,0 +1,26 @@
+# Tessl Skill Review & Optimize — review on PRs that touch SKILL.md (no secrets required).
+# Docs: https://github.com/tesslio/skill-review-and-optimize
+name: Skill review and optimize
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review-and-optimize@main
+        # Review-only by default — works without TESSL_API_TOKEN.
+        # Optional: enable optimize after adding repo secret TESSL_API_TOKEN:
+        # with:
+        #   optimize: true
+        #   tessl-token: ${{ secrets.TESSL_API_TOKEN }}
+        # Optional quality gate:
+        #   fail-threshold: 70

--- a/.github/workflows/skill-review-apply-optimize.yml
+++ b/.github/workflows/skill-review-apply-optimize.yml
@@ -1,0 +1,24 @@
+# Apply optimized SKILL.md content from review comment when someone comments /apply-optimize.
+# Docs: https://github.com/tesslio/skill-review-and-optimize
+name: Apply skill optimization
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  apply:
+    if: >
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/apply-optimize')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: tesslio/skill-review-and-optimize@main
+        with:
+          mode: apply

--- a/plugin/skills/coquill-analyzer/SKILL.md
+++ b/plugin/skills/coquill-analyzer/SKILL.md
@@ -27,7 +27,7 @@ python <script_path> <template_dir> [--force]
 
 Pass `--force` if the Orchestrator requests re-analysis (skips the cache check).
 
-The script handles: format detection, caching, text extraction (including docx XML merge), two-pass analysis, type inference, condition parsing, loop sub-variable extraction, dependency graph construction, config.yaml merge, and manifest save.
+The script handles: format detection, caching, text extraction (including docx XML merge), two-pass analysis, type inference, condition parsing, loop sub-variable extraction, dependency graph construction, config.yaml merge, and manifest save. For implementation details, see `scripts/analyze.py`.
 
 ### Interpret Script Output
 

--- a/plugin/skills/coquill-renderer/SKILL.md
+++ b/plugin/skills/coquill-renderer/SKILL.md
@@ -70,8 +70,8 @@ Do NOT attempt `docx2pdf` or `soffice` in Cowork — they fail due to sandbox re
 The script's JSON output includes a `validation` object:
 
 - **`validation.passed == true`**: All placeholders and control tags were processed. The document is ready.
-- **`validation.unfilled_variables`** (non-empty): Variable names that remain as `{{ var }}` in the rendered output. Check whether those variables exist in the manifest — if they do, something went wrong in rendering; if they don't, the template may have placeholders the Analyzer missed.
-- **`validation.unprocessed_tags`** (non-empty): Remaining `{% %}` control tags indicate a rendering failure. Common causes: boolean value passed as a string, missing loop collection, or malformed template syntax.
+- **`validation.unfilled_variables`** (non-empty): Variable names that remain as `{{ var }}` in the output — cross-check against the manifest to determine if it is a rendering bug or an Analyzer gap.
+- **`validation.unprocessed_tags`** (non-empty): Remaining `{% %}` control tags — likely a boolean passed as a string, missing loop collection, or malformed template syntax.
 
 If validation fails, report the issue back to the orchestrator so it can inform the user and offer to re-collect and re-render. Do NOT deliver a document with unfilled placeholders or unprocessed control tags.
 
@@ -87,4 +87,4 @@ Return to the orchestrator:
 ## Important Notes
 
 - **For docx templates**, always use `docxtpl` — not raw python-docx with string replacement. `docxtpl` preserves formatting around placeholders and natively supports Jinja2 control tags.
-- **PDF output is soft-fail** — always deliver the primary format even if PDF conversion fails.
+- For render script internals (boolean coercion, job folder naming, template engine selection), see `scripts/render.py`.

--- a/plugin/skills/coquill-transcriber/SKILL.md
+++ b/plugin/skills/coquill-transcriber/SKILL.md
@@ -25,9 +25,17 @@ transcript of every micro-turn. When a user answered multiple questions at once,
 records the net result. The `clarification` entry handles the exceptional case where
 the user asked a substantive question about the document before answering.
 
+## Pre-flight Check
+
+Before invoking the script, verify the required input files exist:
+- `interview_log.json` at the provided `interview_log_path`
+- `manifest.yaml` at the provided `manifest_path`
+
+If either is missing, report the error to the Orchestrator immediately — do not invoke the script.
+
 ## Run the Script
 
-Resolve the script path relative to the project root and invoke it:
+Resolve the script path: use `$CLAUDE_PLUGIN_ROOT/scripts/transcribe.py` when `CLAUDE_PLUGIN_ROOT` is set, otherwise `scripts/transcribe.py` relative to the project root.
 
 ```bash
 python scripts/transcribe.py \

--- a/plugin/skills/coquill/SKILL.md
+++ b/plugin/skills/coquill/SKILL.md
@@ -90,23 +90,9 @@ Initialize the log with one entry:
 `2026-03-01T12:03:00+08:00`). For `question` entries, timestamp is when Claude sent the
 question; for `answer` entries, when the user's response was received.
 
-Entry types appended during Phases 4 and 5:
-  prefill           — variables extracted from opening message (list of {name, label, value})
-  group_start       — begins a named group (branch: "if"/"else"/"skipped" for conditionals)
-  question          — effective question(s) asked in one turn; include `questions` (array of variable names asked about)
-  clarification     — substantive user question + Claude's response (user_question, claude_response)
-  answer            — effective final answer, near-verbatim
-  validation_retry  — re-ask after failed validation (reason)
-  skip              — variable/group skipped, with human-readable reason
-  loop_item         — confirmed loop item (item_index, question, answer, values dict)
-  correction        — Phase 5 edit (field, label, old_value, new_value, optional note)
+Entry types appended during Phases 4 and 5: `prefill` (variables from opening message), `group_start` (named group, with branch for conditionals), `question` (questions array), `clarification` (user_question + claude_response), `answer` (near-verbatim), `validation_retry` (reason), `skip` (reason), `loop_item` (item_index, question, answer, values), `correction` (field, label, old_value, new_value).
 
-Entry type appended when a skill or script is invoked:
-  tool_use          — records a skill/script invocation:
-                        tool: skill or script name (e.g. "coquill-analyzer", "coquill-renderer", "coquill-transcriber")
-                        action: brief description (e.g. "Parsed template and generated manifest")
-                        timestamp: when invoked (ISO 8601)
-                        completed_at: when finished (ISO 8601)
+`tool_use` entries record skill/script invocations: `tool`, `action`, `timestamp`, `completed_at`.
 
 This log is scoped to ONE document assembly. Reset it at the start of Phase 3d whenever
 you begin preparing a new document.


### PR DESCRIPTION
Hey @houfu 👋

Really impressive work on CoQuill — the conversational document assembly approach is clever, and the skill separation (orchestrator → analyzer → renderer → transcriber) is well-architected. The v2 spec with conditionals, loops, and config.yaml is a solid foundation.

<img width="1312" height="834" alt="image" src="https://github.com/user-attachments/assets/e50ac2b6-4040-4ca3-9eae-4ea2c1ae1163" />


I ran your skills through **`tessl skill review`** (Anthropic-style agent eval) and found a few targeted improvements — mostly around conciseness, progressive disclosure, and workflow robustness. Here are the before/after scores:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| coquill (Orchestrator) | 94% | 94% | — |
| coquill-analyzer | 90% | 94% | +4% |
| coquill-renderer | 85% | 88% | +3% |
| coquill-transcriber | 89% | 94% | +5% |

<details>
<summary>Changes summary</summary>

**coquill-renderer** (85% → 88%):
- Removed duplicate PDF soft-fail mention that appeared in both Step 4 and Important Notes
- Tightened validation interpretation wording — Claude can infer common causes without verbose explanation
- Added progressive disclosure reference to `scripts/render.py` for implementation details

**coquill-transcriber** (89% → 94%):
- Added pre-flight input file check (verify `interview_log.json` and `manifest.yaml` exist before invoking script)
- Added `CLAUDE_PLUGIN_ROOT` path resolution for consistency with analyzer and renderer skills

**coquill-analyzer** (90% → 94%):
- Added script reference for progressive disclosure (`scripts/analyze.py`)

**coquill (Orchestrator)** (94% → 94%):
- Condensed interview log entry type definitions from verbose multi-line format to compact inline format, reducing token count without losing information

All changes synced to both `.claude/skills/` (source of truth) and `plugin/skills/` (distribution copy).

</details>

## GitHub Actions — Skill Review & Optional Optimize

This PR also adds two workflow files from **[tesslio/skill-review-and-optimize](https://github.com/tesslio/skill-review-and-optimize)**:

- **`.github/workflows/skill-review-and-optimize.yml`** — runs on PRs that change `**/SKILL.md`, posts (or updates) **one comment** with scores and feedback. **No secrets required** — works out of the box with `GITHUB_TOKEN`.
- **`.github/workflows/skill-review-apply-optimize.yml`** — lets PR participants comment **`/apply-optimize`** to auto-commit suggested improvements to the PR branch.

**Review mode is on by default** (non-blocking). To enable AI-powered optimization suggestions:
1. Add **`TESSL_API_TOKEN`** as a repo secret (get one from [tessl.io](https://tessl.io))
2. Uncomment the `with:` block in the review workflow (`optimize: true` + `tessl-token`)
3. Contributors can then accept suggestions by commenting **`/apply-optimize`** on any PR

The action is **non-blocking by default** — no PR will fail unless you set a `fail-threshold`. It's review/optimize automation for markdown skills, not a replacement for any existing pipelines.

**Why only four skills in this PR?** That's all the skills in the repo! The workflows will give ongoing feedback on any future `SKILL.md` changes automatically.

Honest disclosure — I work at [tessl.io](https://tessl.io) (@tesslio) where we build tooling around agent skills. Not a pitch, just fixes that were straightforward to make after running evals.

For more on skill best practices: [optimize a skill using best practices](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices). If you hit any snags, feel free to ping [@rohan-tessl](https://github.com/rohan-tessl).

Thanks in advance 🙏
