### PR TITLE
Add template linting and Word artifact sanitization

### DIFF
--- a/.claude/skills/coquill-analyzer/SKILL.md
+++ b/.claude/skills/coquill-analyzer/SKILL.md
@@ -44,8 +44,19 @@ After a fresh analysis (not a cache hit), load `manifest.yaml` and check for iss
 3. **Conditional variables shadowing unconditional** — if the same variable name appears in both `variables` and a conditional's `if_variables`/`else_variables`, flag it. The script deduplicates these, but a config.yaml merge could reintroduce duplicates.
 4. **Loop sub-variables with no names** — if a loop's `variables` list is empty, the loop collects nothing. This may be intentional (iteration-only) or a sign the template uses a non-standard loop variable pattern.
 5. **Config.yaml drift** — if `config.yaml` exists, quickly scan it for variable names that don't appear anywhere in the manifest. These are config entries for variables the template no longer uses. Warn so the developer can clean up.
+6. **Sanitize/lint warnings** — if `manifest.warnings` is present and non-empty, surface each entry to the Orchestrator. These are author-actionable issues the script auto-corrected during analysis: smart quotes inside tag bodies (Word autocorrect), unrecognized docxtpl prefixes (`{%p`/`{%tr`/`{%tc`) that were stripped for analysis only, and undefined Jinja callables that will fail at render time. Each warning is a string formatted as `"<code>: <detail>"` (codes: `smart_quote`, `docxtpl_prefix`, `undefined_callable`).
 
 Report any warnings alongside the manifest contents when returning to the Orchestrator.
+
+### Lint-only mode
+
+If the Orchestrator wants warnings without writing a manifest, invoke:
+
+```bash
+python <script_path> <template_dir> --lint
+```
+
+This runs extract → sanitize → callable-detect, prints warnings to stdout, and exits non-zero if any are found. No `manifest.yaml` is written.
 
 ## Step 3 — Return to Orchestrator
 

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -109,6 +109,116 @@ def extract_text(template_path, template_format):
     return text
 
 
+# Jinja2 built-in globals + docxtpl runtime helpers. Callable references
+# in {{ }} / {% %} bodies that aren't in this set get flagged by
+# detect_undefined_callables() below. False positives are acceptable —
+# the warning prompts the author to register the helper or rewrite.
+KNOWN_CALLABLES = {
+    "range",
+    "dict",
+    "lipsum",
+    "cycler",
+    "joiner",
+    "namespace",
+    "R",
+    "RichText",
+    "Subdoc",
+    "InlineImage",
+    "Listing",
+}
+
+
+_RE_BLOCK_TAG = re.compile(r"\{%-?\s*(.*?)\s*-?%\}", re.DOTALL)
+_RE_VAR_TAG = re.compile(r"\{\{\s*(.*?)\s*\}\}", re.DOTALL)
+_RE_DOCXTPL_PREFIX = re.compile(
+    r"\{%([-\s]*)(p|tr|tc)(?=[-\s]*(?:if|else|elif|endif|for|endfor)\b)"
+)
+
+
+def _iter_tag_bodies(text):
+    """Yield (match_start, match_end, body) for every {% %} and {{ }}."""
+    for m in _RE_BLOCK_TAG.finditer(text):
+        yield m.start(), m.end(), m.group(1)
+    for m in _RE_VAR_TAG.finditer(text):
+        yield m.start(), m.end(), m.group(1)
+_SMART_QUOTE_MAP = {
+    "“": '"',
+    "”": '"',
+    "‘": "'",
+    "’": "'",
+}
+
+
+def sanitize_for_analysis(text):
+    """Normalize Word-introduced artifacts inside Jinja tag bodies.
+
+    Returns (sanitized_text, warnings). The original template file is
+    not modified; this only rewrites the analysis-time string so the
+    downstream regex walker can recognize prefixed tags and equality
+    conditions that Word's autocorrect mangled.
+    """
+    warnings = []
+
+    def _strip_prefix(m):
+        prefix = m.group(2)
+        warnings.append(
+            f"docxtpl_prefix: stripped {prefix!r} prefix from "
+            f"{{%{prefix}...%}} at offset {m.start()}"
+        )
+        return "{%" + m.group(1)
+
+    text = _RE_DOCXTPL_PREFIX.sub(_strip_prefix, text)
+
+    # Replace smart quotes only inside tag bodies. Prose may legitimately
+    # use curly quotes, so we don't touch text outside {% %} / {{ }}.
+    spans = sorted(
+        [(s, e) for s, e, _ in _iter_tag_bodies(text)], key=lambda x: x[0]
+    )
+    chars = list(text)
+    for start, end in spans:
+        for i in range(start, end):
+            ch = chars[i]
+            if ch in _SMART_QUOTE_MAP:
+                straight = _SMART_QUOTE_MAP[ch]
+                warnings.append(
+                    f"smart_quote: replaced U+{ord(ch):04X} with "
+                    f"{straight} in tag at offset {i}"
+                )
+                chars[i] = straight
+    return "".join(chars), warnings
+
+
+_RE_CALLABLE_IN_BODY = re.compile(r"(?<![\w.])(\w+)\s*\(")
+
+
+def detect_undefined_callables(text):
+    """Flag callable references in tag bodies that aren't registered
+    with the default Jinja2 + docxtpl environment."""
+    occurrences = {}
+    for _start, _end, body in _iter_tag_bodies(text):
+        for cm in _RE_CALLABLE_IN_BODY.finditer(body):
+            name = cm.group(1)
+            if name in KNOWN_CALLABLES:
+                continue
+            # Skip Jinja control keywords that legitimately appear
+            # before a paren-less expression (none of these should
+            # match \w+\( anyway, but be defensive).
+            if name in {"if", "elif", "else", "endif", "for", "endfor",
+                        "in", "and", "or", "not", "is", "true", "false",
+                        "True", "False", "None", "none"}:
+                continue
+            occurrences[name] = occurrences.get(name, 0) + 1
+
+    warnings = []
+    for name, count in occurrences.items():
+        plural = "occurrence" if count == 1 else "occurrences"
+        warnings.append(
+            f"undefined_callable: {name} ({count} {plural}) is not a "
+            f"registered Jinja global, filter, or docxtpl helper"
+        )
+    return warnings
+
+
 def analyze_template(text):
     """Two-pass analysis: find tags, classify variables into scopes."""
     # Regex patterns
@@ -291,7 +401,7 @@ def build_var_entry(name, boolean_gate_vars, infer_name=None):
 
 def build_manifest(
     template_dir, template_file, template_format, unconditional_vars,
-    conditionals, loops, boolean_gate_vars, config_path,
+    conditionals, loops, boolean_gate_vars, config_path, warnings=None,
 ):
     """Build the manifest dict from analyzed data and optional config."""
     # Build final variable lists
@@ -412,6 +522,9 @@ def build_manifest(
     if config and "validation" in config:
         manifest["validation"] = config["validation"]
 
+    if warnings:
+        manifest["warnings"] = warnings
+
     return manifest, variable_count
 
 
@@ -425,6 +538,14 @@ def main():
         action="store_true",
         help="Force regeneration, skip cache check",
     )
+    parser.add_argument(
+        "--lint",
+        action="store_true",
+        help=(
+            "Report sanitize/lint warnings only; do not write manifest. "
+            "Exits non-zero if any warnings are found."
+        ),
+    )
     args = parser.parse_args()
 
     template_dir = args.template_dir
@@ -433,18 +554,29 @@ def main():
     template_file, template_format = detect_template(template_dir)
     template_path = os.path.join(template_dir, template_file)
 
-    # Step 2: Check cache
+    # Step 2: Check cache (skipped in --lint mode; lint always re-runs)
     manifest_path = os.path.join(template_dir, "manifest.yaml")
     config_path = os.path.join(template_dir, "config.yaml")
 
-    if not args.force:
+    if not args.force and not args.lint:
         needs_regen = check_cache(manifest_path, template_path, config_path)
         if not needs_regen:
             print("Manifest is up to date. Skipping analysis.")
             sys.exit(0)
 
-    # Step 3: Extract text
+    # Step 3: Extract text and sanitize Word-introduced artifacts
     text = extract_text(template_path, template_format)
+    text, sanitize_warnings = sanitize_for_analysis(text)
+    callable_warnings = detect_undefined_callables(text)
+    warnings = sanitize_warnings + callable_warnings
+
+    if args.lint:
+        if warnings:
+            for w in warnings:
+                print(w)
+            sys.exit(1)
+        print("No lint warnings.")
+        sys.exit(0)
 
     # Step 4: Analyze
     unconditional_vars, conditionals, loops, boolean_gate_vars = analyze_template(text)
@@ -453,7 +585,7 @@ def main():
     manifest, variable_count = build_manifest(
         template_dir, template_file, template_format,
         unconditional_vars, conditionals, loops, boolean_gate_vars,
-        config_path,
+        config_path, warnings,
     )
 
     # Step 9: Write manifest
@@ -467,6 +599,8 @@ def main():
     print(f"  Variables: {variable_count}")
     print(f"  Conditionals: {len(manifest['conditionals'])}")
     print(f"  Loops: {len(manifest['loops'])}")
+    if warnings:
+        print(f"  Warnings: {len(warnings)}")
 
 
 if __name__ == "__main__":

--- a/tests/fixtures/templates/word_artifacts/template.md
+++ b/tests/fixtures/templates/word_artifacts/template.md
@@ -1,0 +1,10 @@
+{%p if jurisdiction_type == “siac” %}
+This Agreement shall be governed by the SIAC Rules.
+{%p endif %}
+
+Parties:
+{%p for party in parties_list %}
+- {{ party.name }}, incorporated in {{ party.place_of_incorporation }}
+{%p endfor %}
+
+This Agreement is governed by {{ country_name(governing_law) }}.

--- a/tests/harness/test_manifest.py
+++ b/tests/harness/test_manifest.py
@@ -222,10 +222,89 @@ def test_config_merge() -> bool:
     return ok
 
 
+def test_word_artifacts() -> bool:
+    """Smart quotes, {%p prefixes, and undefined callables produce
+    warnings and don't break analysis."""
+    print("\n=== Test: word_artifacts ===")
+    fixture_dir = FIXTURES_DIR / "word_artifacts"
+    run_analyzer(fixture_dir)
+    manifest = load_manifest(fixture_dir)
+
+    ok = True
+
+    conds = manifest.get("conditionals", [])
+    ok &= assert_eq("conditionals count", len(conds), 1)
+    if conds:
+        c = conds[0]
+        ok &= assert_eq("cond.gate_type", c.get("gate_type"), "equality")
+        ok &= assert_eq("cond.gate_variable", c.get("gate_variable"), "jurisdiction_type")
+        ok &= assert_eq("cond.gate_value", c.get("gate_value"), "siac")
+
+    loops = manifest.get("loops", [])
+    ok &= assert_eq("loops count", len(loops), 1)
+    if loops:
+        L = loops[0]
+        ok &= assert_eq("loop.loop_var", L.get("loop_var"), "party")
+        ok &= assert_eq("loop.collection", L.get("collection"), "parties_list")
+        sub_names = sorted(v["name"] for v in L.get("variables", []))
+        ok &= assert_eq("loop sub-vars", sub_names, ["name", "place_of_incorporation"])
+
+    warnings = manifest.get("warnings", [])
+    has_smart_quote = any(w.startswith("smart_quote:") for w in warnings)
+    has_prefix = any(w.startswith("docxtpl_prefix:") for w in warnings)
+    has_callable = any(
+        w.startswith("undefined_callable: country_name") for w in warnings
+    )
+    ok &= assert_eq("warnings has smart_quote", has_smart_quote, True)
+    ok &= assert_eq("warnings has docxtpl_prefix", has_prefix, True)
+    ok &= assert_eq("warnings has undefined_callable", has_callable, True)
+
+    return ok
+
+
+def test_lint_flag() -> bool:
+    """--lint exits non-zero on warnings and writes no manifest."""
+    print("\n=== Test: lint_flag ===")
+    fixture_dir = FIXTURES_DIR / "word_artifacts"
+    manifest_path = fixture_dir / "manifest.yaml"
+    if manifest_path.exists():
+        manifest_path.unlink()
+
+    result = subprocess.run(
+        ["uv", "run", str(ANALYZE_PY), str(fixture_dir), "--lint"],
+        capture_output=True,
+        text=True,
+        cwd=str(TESTS_DIR),
+    )
+
+    ok = True
+    ok &= assert_eq("lint exit code", result.returncode, 1)
+    ok &= assert_eq("manifest written", manifest_path.exists(), False)
+    ok &= assert_eq(
+        "lint stdout has smart_quote",
+        any(line.startswith("smart_quote:") for line in result.stdout.splitlines()),
+        True,
+    )
+    ok &= assert_eq(
+        "lint stdout has docxtpl_prefix",
+        any(line.startswith("docxtpl_prefix:") for line in result.stdout.splitlines()),
+        True,
+    )
+    ok &= assert_eq(
+        "lint stdout has undefined_callable",
+        any(line.startswith("undefined_callable:") for line in result.stdout.splitlines()),
+        True,
+    )
+
+    return ok
+
+
 def main():
     results = []
     results.append(("type_inference", test_type_inference()))
     results.append(("config_merge", test_config_merge()))
+    results.append(("word_artifacts", test_word_artifacts()))
+    results.append(("lint_flag", test_lint_flag()))
 
     print(f"\n{'='*60}")
     print("SUMMARY")


### PR DESCRIPTION
## Summary

This PR adds comprehensive linting and sanitization capabilities to the template analyzer to detect and correct Word-introduced artifacts and undefined Jinja callables that would fail at render time.

## Key Changes

- **Sanitization pipeline**: Added `sanitize_for_analysis()` to normalize Word autocorrect artifacts (smart quotes, docxtpl prefixes like `{%p`) inside Jinja tag bodies before analysis. Original template files remain unchanged; sanitization is analysis-time only.

- **Callable detection**: Implemented `detect_undefined_callables()` to flag Jinja function calls in templates that aren't registered with the default Jinja2 + docxtpl environment. Maintains a `KNOWN_CALLABLES` set of built-in globals and docxtpl helpers (`range`, `dict`, `RichText`, `Subdoc`, `InlineImage`, etc.).

- **Lint mode**: Added `--lint` CLI flag that runs extract → sanitize → callable-detect, prints warnings to stdout, and exits non-zero if any are found. No manifest is written in this mode, allowing the Orchestrator to check for issues without side effects.

- **Warning collection**: Modified `build_manifest()` to accept and include warnings in the output manifest under a `warnings` key. Each warning is formatted as `"<code>: <detail>"` with codes: `smart_quote`, `docxtpl_prefix`, `undefined_callable`.

- **Test coverage**: Added `test_word_artifacts()` to verify sanitization and callable detection work correctly, and `test_lint_flag()` to verify `--lint` mode behavior.

- **Documentation**: Updated SKILL.md with sanitization/lint warning details and lint-only invocation instructions.

## Implementation Details

- Smart quote replacement is scoped to tag bodies only (via `_iter_tag_bodies()`), preserving legitimate curly quotes in prose.
- Docxtpl prefix stripping (`{%p`, `{%tr`, `{%tc`) is regex-based and generates warnings for each occurrence.
- Callable detection uses regex to find `name(` patterns in tag bodies, filtering out Jinja keywords and known globals.
- Cache check is skipped in `--lint` mode to ensure fresh analysis on every invocation.

https://claude.ai/code/session_01JZSs2LFRxiQDXQbM2ErRys